### PR TITLE
fix: API rate limiting, date difference checking, etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,21 @@
 const config = require('./config');
 const axios = require('axios');
+const { RateLimiter } = require('limiter');
 
-const getWeek = (date) => {
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
-  const week1 = new Date(date.getFullYear(), 0, 4);
+const secondLimiter = new RateLimiter({ tokensPerInterval: 1, interval: 2000 });
+const hourLimiter = new RateLimiter({ tokensPerInterval: 250, interval: 'hour' });
 
-  return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 -
-                3 + (week1.getDay() + 6) % 7) / 7);
-};
+const rateLimitOpenCVE = async (func) => {
+  await secondLimiter.removeTokens(1);
+  await hourLimiter.removeTokens(1);
+  return await func();
+}
+
+const datesAreCloseEnough = (date1, date2, diffMs) => {
+  return Math.abs(date1.getTime() - date2.getTime()) <= diffMs;
+}
+
+const weekInMilliseconds = 1000 * 60 * 60 * 24 * 7;
 
 const getPageOfMediums = async (vendor, page) => {
   const url = `https://www.opencve.io/api/cve?cvss=medium&page=${page}&vendor=${vendor}`;
@@ -16,60 +23,60 @@ const getPageOfMediums = async (vendor, page) => {
   const headerAuth = Buffer.from(authString).toString('base64');
 
   try {
-    const res = await axios.get(url, {
-      headers: {
-        'Authorization': `Basic ${headerAuth}`,
-      },
-    }).catch(err => { /* who cares */ })
+    const res = await rateLimitOpenCVE(() => axios.get(url, {
+        headers: {
+          'Authorization': `Basic ${headerAuth}`,
+        }
+      }));
 
     return res.data;
   } catch (e) {
+    if ([404].includes(e.response.status)) {
+      return [];
+    }
+    throw e;
+  }
+};
+
+const openCVEPageSize = 20;
+
+const collectMediums = async (vendor, currentPage = 1, currentDate = new Date()) => {
+  const page = await getPageOfMediums(vendor, currentPage);
+
+  if (!page || page.length === 0 || page.message) {
     return [];
   }
 
-};
-
-const filterDataForWeek = (data, week) => {
-  return data.filter((e) => {
-    const weekOfE = getWeek(new Date(e.created_at));
-    return weekOfE === week;
+  const currentDateCVEs = page.filter(event => {
+    if (!event.created_at || !event.summary) {
+      return false;
+    }
+    return datesAreCloseEnough(currentDate, new Date(event.created_at), weekInMilliseconds);
   });
-};
 
-const collectMediums = async (vendor, currentPage = 1, collected = []) => {
-  const page = await getPageOfMediums(vendor, currentPage);
-  const currentWeek = getWeek(new Date());
+  if (page.length < openCVEPageSize)
+    return currentDateCVEs;
 
-  if (!page || page.length == 0 || page.message) {
-    return collected;
-  }
-
-  const dataFromLastWeek = filterDataForWeek(page, currentWeek - 1);
-  const dataFromWeekBeforeLast = filterDataForWeek(page, currentWeek - 2);
-
-  const collectedNow = collected.concat(dataFromLastWeek);
-
-  if (dataFromWeekBeforeLast.length === 0) {
-    return collectMediums(vendor, currentPage + 1, collectedNow);
-  }
-
-  return collectedNow;
-};
-
-const collectForVendors = async (vendorList) => {
-  let totalCollected = [];
-
-  for (let i = 0; i < vendorList.length; i++) {
-    const vendor = vendorList[i];
-    const collectedFromVendor = await collectMediums(vendor);
-    totalCollected = [...totalCollected, ...collectedFromVendor];
-  }
-
-  return totalCollected;
-};
-
-collectForVendors(config.vendors).then((collected) => {
-  for (const {id, summary, created_at} of collected) {
+  currentDateCVEs.forEach((cve) => {
+    if (!('summary' in cve))
+      return;
+    const { id, summary, created_at } = cve;
     console.log(`\n- "${id}" created at ${created_at}\n${summary}\n`);
+  });
+
+  let allEventsAreOutdated = true;
+  for (let event of page) {
+    if (datesAreCloseEnough(currentDate, new Date(event.updated_at), weekInMilliseconds))
+      allEventsAreOutdated = false;
   }
-});
+  if (allEventsAreOutdated)
+    return currentDateCVEs;
+
+  return [...currentDateCVEs, collectMediums(vendor, currentPage + 1)];
+};
+
+(async () => {
+  for (let vendor of config.vendors) {
+    await collectMediums(vendor);
+  }
+})()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.3.4"
+    "axios": "^1.3.4",
+    "limiter": "^2.1.0"
   }
 }


### PR DESCRIPTION
This fixes a multitude of things. First, it makes calls to opencve.io respect its rate limits (250 requests per hour, one call per second). Second, it teaches the script to only print vulnerabilities that occured in the last 7 days instead of trying to deduce whether those happened on the same calendar week.

The script is also reworked to a) print vulnerabilities as soon as they conform to the printing conditions b) stop execution for every stated vendor as soon as the last update date of all found CVEs has obviously been too long ago.

Truth be told, the program needs a rewrite, but for now this makes the script work.